### PR TITLE
fix: add missing `peerDependencies` stanza

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,5 +48,8 @@
     "tap": "^15.1.5",
     "ts-node": "^10.4.0",
     "typescript": "^4.5.3"
+  },
+  "peerDependencies": {
+    "graphql": "0.13.1 - 16"
   }
 }


### PR DESCRIPTION
I'm getting `mercurius-upload@npm:3.0.0 doesn't provide graphql (pe984a), requested by graphql-upload` warning from yarn.

Range selected is to match [`graphql-upload`](https://github.com/jaydenseric/graphql-upload/blob/0cbc9d90a181ace59be279fee4c3b269c47d1cbe/package.json#L46-L48), but could also be set to match [`mercurius`](https://github.com/mercurius-js/mercurius/blob/71479c4a747449b54a5f6d2134f629eaa4170d68/package.json#L28-L30) (although it should probably also include v16)