### PR TITLE
fix: rename `isMultipart` to `mercuriusUploadMultipart`

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -5,7 +5,7 @@ import type { FastifyPluginCallback } from 'fastify'
 
 declare module 'fastify' {
   interface FastifyRequest {
-    mercuriusUploadMulutipart?: true
+    mercuriusUploadMultipart?: true
   }
 }
 
@@ -15,12 +15,12 @@ const mercuriusGQLUpload: FastifyPluginCallback<UploadOptions> = (
   done
 ) => {
   fastify.addContentTypeParser('multipart', (req, _payload, done) => {
-    req.mercuriusUploadMulutipart = true
+    req.mercuriusUploadMultipart = true
     done(null)
   })
 
   fastify.addHook('preValidation', async function (request, reply) {
-    if (!request.mercuriusUploadMulutipart) {
+    if (!request.mercuriusUploadMultipart) {
       return
     }
 

--- a/index.ts
+++ b/index.ts
@@ -5,7 +5,7 @@ import type { FastifyPluginCallback } from 'fastify'
 
 declare module 'fastify' {
   interface FastifyRequest {
-    isMultipart?: true
+    mercuriusUploadMulutipart?: true
   }
 }
 
@@ -15,12 +15,12 @@ const mercuriusGQLUpload: FastifyPluginCallback<UploadOptions> = (
   done
 ) => {
   fastify.addContentTypeParser('multipart', (req, _payload, done) => {
-    req.isMultipart = true
+    req.mercuriusUploadMulutipart = true
     done(null)
   })
 
   fastify.addHook('preValidation', async function (request, reply) {
-    if (!request.isMultipart) {
+    if (!request.mercuriusUploadMulutipart) {
       return
     }
 


### PR DESCRIPTION
The declaration of `isMultipart` in this module conflicts with the one in [`fastify-multipart`](https://github.com/fastify/fastify-multipart/blob/3c68fab08967f1abfce9edda73fee95a3f7166b2/index.d.ts#L54). The one there seems more generally useful, so I suggest renaming here.

`fastify` encapsulation makes sure this isn't an issue at runtime, but TS is unhappy.

<img width="1808" alt="image" src="https://user-images.githubusercontent.com/1404810/159481840-c5bc9827-3082-4f69-936a-92efd11f9a41.png">

(issues aren't enabled, otherwise I'd use that - not sure about just changing the name).