### PR TITLE
fix: request hangs

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,3 +1,4 @@
+import stream from 'stream';
 import fp from 'fastify-plugin'
 import processRequest, {
   ProcessRequestOptions,
@@ -27,6 +28,14 @@ const mercuriusGQLUpload: FastifyPluginCallback<ProcessRequestOptions> = (
     }
 
     request.body = await processRequest(request.raw, reply.raw, options)
+  })
+
+  fastify.addHook('onSend', async function (request) {
+    if (!request.mercuriusUploadMultipart) {
+      return
+    }
+
+    await stream.promises.finished(request.raw)
   })
 
   done()

--- a/index.ts
+++ b/index.ts
@@ -1,8 +1,11 @@
+import * as util from 'util';
 import stream from 'stream';
 import fp from 'fastify-plugin'
 import processRequest, {
   ProcessRequestOptions,
 } from 'graphql-upload/processRequest.js'
+
+const finishedStream = util.promisify(stream.finished);
 
 import type { FastifyPluginCallback } from 'fastify'
 
@@ -35,7 +38,7 @@ const mercuriusGQLUpload: FastifyPluginCallback<ProcessRequestOptions> = (
       return
     }
 
-    await stream.promises.finished(request.raw)
+    await finishedStream(request.raw)
   })
 
   done()


### PR DESCRIPTION
I tried `events` approach, but it didn't work. And I tried to use `done` callback, but I can't pass the unit tests - "Cannot set headers after they are sent to the client"
Also, I don't know about creating new unit tests because mocked client is used, requests will be correct even without this fix