### PR TITLE
Support Fastify 5 which seemingly parses content types differently (multipart/form-data fails)

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -18,7 +18,7 @@ const mercuriusGQLUpload: FastifyPluginCallback<UploadOptions> = (
   options,
   done,
 ) => {
-  fastify.addContentTypeParser(/multipart(\/.*)?/, (req, _payload, done) => {
+  fastify.addContentTypeParser(/^multipart(\/.*)?/, (req, _payload, done) => {
     req.mercuriusUploadMultipart = true
     done(null)
   })

--- a/index.ts
+++ b/index.ts
@@ -18,7 +18,7 @@ const mercuriusGQLUpload: FastifyPluginCallback<UploadOptions> = (
   options,
   done,
 ) => {
-  fastify.addContentTypeParser('multipart', (req, _payload, done) => {
+  fastify.addContentTypeParser(/multipart(\/.*)?/, (req, _payload, done) => {
     req.mercuriusUploadMultipart = true
     done(null)
   })


### PR DESCRIPTION
After our upgrade to Fastify 5 the uploads started to fail. A quick investigation revealed the form body (passed as multipart/form-data) yielded an error `Unsupported Media Type: multipart/form-data; boundary=----WebKitFormBoundaryS8miSu0RFYkC4aYK`.

This wildcard match works both for Fastify 4.x and 5.x. Until now, we are living with a patched version of this package. However, the change and this adaptation is tiny - if this fix is unacceptable, I am ok creating our own adaptation.