### PR TITLE
Narrow supported Fastify version to 5.x

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -43,7 +43,7 @@ const mercuriusGQLUpload: FastifyPluginCallback<UploadOptions> = (
 }
 
 export const mercuriusUpload = fp(mercuriusGQLUpload, {
-  fastify: '>= 4.x',
+  fastify: '5.x',
   name: 'mercurius-upload',
 })
 


### PR DESCRIPTION
Narrowing the supported Fastify version to `5.x` to ensure the plugin works as expected in the supported versions defined in the README.

Once merged, we are all good to release I believe! :)