### PR TITLE
chore: add Node.js 24.x to test matrix and migrate to node test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [20.x, 22.x]
+        node-version: [20.x, 22.x, 24.x]
         os: [ubuntu-latest, windows-latest, macOS-latest]
     steps:
       - uses: actions/checkout@v3

--- a/package.json
+++ b/package.json
@@ -29,24 +29,22 @@
   ],
   "scripts": {
     "prepack": "tsc && prettier --write dist index.ts test",
-    "test": "tap --ts --100 test/*.test.ts"
+    "test": "node --require ts-node/register --test test/*.test.ts"
   },
   "dependencies": {
-    "fastify-plugin": "^5.0.1",
-    "graphql-upload-minimal": "^1.6.1"
+    "fastify-plugin": "^5.1.0",
+    "graphql-upload-minimal": "^1.6.4"
   },
   "devDependencies": {
-    "@types/node": "^20.5.0",
-    "@types/tap": "^15.0.7",
-    "cross-env": "^7.0.3",
-    "fastify": "^5.0.0",
-    "form-data": "^4.0.1",
-    "graphql": "^16.5.0",
-    "mercurius": "^15.0.0",
-    "prettier": "^3.3.3",
-    "tap": "^16.2.0",
+    "@types/node": "^24.10.4",
+    "borp": "^0.21.0",
+    "fastify": "^5.6.2",
+    "form-data": "^4.0.5",
+    "graphql": "^16.12.0",
+    "mercurius": "^16.6.0",
+    "prettier": "^3.7.4",
     "ts-node": "^10.9.2",
-    "typescript": "^5.6.3"
+    "typescript": "^5.9.3"
   },
   "peerDependencies": {
     "graphql": "^16.3.0"

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
   },
   "devDependencies": {
     "@types/node": "^24.10.4",
-    "borp": "^0.21.0",
     "fastify": "^5.6.2",
     "form-data": "^4.0.5",
     "graphql": "^16.12.0",

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -1,8 +1,8 @@
-import tap from 'tap'
 import FormData from 'form-data'
+import { test, TestContext } from 'node:test'
 import { build } from './build-server'
 
-tap.test('mercurius-upload - should work', async (t) => {
+test('mercurius-upload - should work', async (t: TestContext) => {
   const server = build()
   await server.ready()
 
@@ -32,13 +32,13 @@ tap.test('mercurius-upload - should work', async (t) => {
     payload: body,
   })
 
-  t.equal(res.statusCode, 200)
-  t.same(JSON.parse(res.body), { data: { uploadImage: fileData } })
+  t.assert.strictEqual(res.statusCode, 200)
+  t.assert.deepStrictEqual(JSON.parse(res.body), { data: { uploadImage: fileData } })
 
   await server.close()
 })
 
-tap.test('Normal gql query should work', async (t) => {
+test('Normal gql query should work', async (t: TestContext) => {
   const server = build()
   await server.ready()
 
@@ -55,8 +55,8 @@ tap.test('Normal gql query should work', async (t) => {
     }),
   })
 
-  t.equal(res.statusCode, 200)
-  t.same(JSON.parse(res.body), {
+  t.assert.strictEqual(res.statusCode, 200)
+  t.assert.deepStrictEqual(JSON.parse(res.body), {
     data: {
       add: 4,
     },
@@ -65,13 +65,13 @@ tap.test('Normal gql query should work', async (t) => {
   await server.close()
 })
 
-tap.test('A normal http request to another route should work', async (t) => {
+test('A normal http request to another route should work', async (t: TestContext) => {
   const server = build()
   await server.ready()
   const res = await server.inject({ method: 'GET', url: '/' })
 
-  t.same(res.statusCode, 200)
-  t.same(res.headers['content-type'], 'application/json; charset=utf-8')
-  t.same(JSON.parse(res.payload), { hello: 'world' })
+  t.assert.strictEqual(res.statusCode, 200)
+  t.assert.strictEqual(res.headers['content-type'], 'application/json; charset=utf-8')
+  t.assert.deepStrictEqual(JSON.parse(res.payload), { hello: 'world' })
   await server.close()
 })

--- a/test/build-server.ts
+++ b/test/build-server.ts
@@ -1,6 +1,6 @@
 import fastify from 'fastify'
-import GQL from 'mercurius'
 import { GraphQLUpload } from 'graphql-upload-minimal'
+import { mercurius as GQL } from 'mercurius'
 import mercuriusGQLUpload from '../index'
 
 const schema = /* GraphQL */ `


### PR DESCRIPTION
This PR adds node 24 in the CI, migrates from tap to node test and upgrades the dependencies